### PR TITLE
Auto SR updates for 7 Days to Die, SotTR

### DIFF
--- a/src/content/games/7_days_to_die.md
+++ b/src/content/games/7_days_to_die.md
@@ -9,6 +9,8 @@ date_tested: 2024-03-25
 os_version: "26085.1"
 driver_id: 31.0.38.4
 auto_super_resolution: 
-    compatibility: yes, out-of-box
+    compatibility: yes, opt-in
     fps boost: 15%+ Boost
+    opt_in_steps: ["Select the game in your Steam library.", "Click on the Settings (Gear) icon, then click Properties.", "On the General tab, under Launch options ensure \"Launch game without EAC\" is selected.", "Close the Settings window.", "Click Play."] 
+---
 ---

--- a/src/content/games/shadow_of_the_tomb_raider.md
+++ b/src/content/games/shadow_of_the_tomb_raider.md
@@ -11,5 +11,5 @@ driver_id: 31.0.38.0
 auto_super_resolution: 
     compatibility: yes, opt-in
     fps boost: 30%+ Boost
-    opt_in_steps: ["Enable Automatic super resolution","Go to System > Display > Graphics setting and turn the automatic super resolution default to \"on\"", "In System > Display > Graphics > Custom settings for applications for Skyrim, set Automatic super resolution to \"On\"", "Set in game settings", "Launch the game", "Under Options > Display, select \"Exclusive Fullscreen\" and the display resolution closet to 800 lines (e.g, 1152x768)", "Click Play"]
+    opt_in_steps: ["Enable Automatic super resolution","Go to System > Display > Graphics setting and turn the automatic super resolution default to \"on\"", "In System > Display > Graphics > Custom settings for applications for Shadow of the Tomb Raider, set Automatic super resolution to \"On\"", "Set in game settings", "Launch the game", "Under Options > Display, select \"Exclusive Fullscreen\" and the display resolution closet to 800 lines (e.g, 1152x768)", "Click Play"]
 ---


### PR DESCRIPTION
Includes a couple of Auto SR updates. 
- Change 7 Days to Die to "opt-in" with instructions on how to launch without EAC. 
- Fix Shadow of the Tomb Raider entry to reference correct game name.