### PR TITLE
[fix] Set the autocomplete "off" for PageFind (Issue #205)

### DIFF
--- a/src/components/Search/PageFind.tsx
+++ b/src/components/Search/PageFind.tsx
@@ -302,6 +302,7 @@ const PageFind = ({
                 })
               }
               class="w-full h-full px-3"
+              autocomplete="off"
             />
 
           <button


### PR DESCRIPTION
Fix for Issue: Search suggestions prevent default action launching the search Linaro#205
Set the autocomplete "off" for PageFind