### PR TITLE
Update path_of_titans.md

### DIFF
--- a/src/content/games/path_of_titans.md
+++ b/src/content/games/path_of_titans.md
@@ -1,10 +1,9 @@
 ---
 reporter: devoid
-name: Path of Titans
+name: "Path of Titans"
 categories: [unknown]
 publisher: Alderon Games
 compatibility: perfect
 compatibility_details: The game supports Qualcomm Snapdragon X1E CPUs or above.
-link: https://pathoftitans.com
 link: https://support.alderongames.com/hc/en-us/articles/50447139453721-Minimum-Specifications-and-Hardware-Compatibility
 ---

--- a/src/content/games/path_of_titans.md
+++ b/src/content/games/path_of_titans.md
@@ -1,6 +1,10 @@
 ---
-name: "Path of Titans"
+reporter: devoid
+name: Path of Titans
 categories: [unknown]
-compatibility: runs
-os_version: "0.0"
+publisher: Alderon Games
+compatibility: perfect
+compatibility_details: The game supports Qualcomm Snapdragon X1E CPUs or above.
+link: https://pathoftitans.com
+link: https://support.alderongames.com/hc/en-us/articles/50447139453721-Minimum-Specifications-and-Hardware-Compatibility
 ---


### PR DESCRIPTION
Updating the status of Path of Titans to reflect its support for ARM-based devices.

The game currently supports Qualcomm Snapdragon X1E CPUs or above.