### PR TITLE
Add Celeste support with new schema

### DIFF
--- a/src/data/content/projects.json
+++ b/src/data/content/projects.json
@@ -18660,14 +18660,15 @@
     "type": "game",
     "icon": "gaming-icon-white.svg",
     "categories": [
-      "unknown"
+      "platformer"
     ],
-    "publisher": "",
-    "compatibility": "no",
-    "emulationType": "none",
-    "validation": "qualcomm",
-    "lastUpdated": "2023-11-01",
-    "shouldShowNotes": false
+    "publisher": "Maddy Makes Games",
+    "compatibility": "yes",
+    "emulationType": "unknown",
+    "validation": "community",
+    "lastUpdated": "2026-01-18",
+    "notes": "Tested on Radxa Dragon Q6A (QCS6490 SoC, Adreno 643 GPU). OS build 26200.7623.",
+    "shouldShowNotes": true
   },
   {
     "slug": "celestia",


### PR DESCRIPTION
Follow-Up on #348

> On Windows 11 25H2 running on Radxa Dragon Q6A (Qualcomm QCS6490 SoC) the game works as expected.
> 
>> Note: Launched from Epic Games Launcher